### PR TITLE
feat: add autocreate default section when creating new group

### DIFF
--- a/routes/group.js
+++ b/routes/group.js
@@ -11,9 +11,14 @@ router.post("groups.create", "/", async ctx => {
   // TODO: create default section
   try {
     await newGroup.save({ fields: ["name", "foundationDate"] });
-    const newDefaultSection = await sectionFunctions.create(ctx, {
+    const {
+      dataValues: defaultSectionType
+    } = await ctx.orm.sectionType.findOne({
+      where: { name: "Sin Unidad" }
+    });
+    await sectionFunctions.create(ctx, {
       name: "Sin Unidad",
-      typeId: 1,
+      typeId: defaultSectionType.id,
       groupId: newGroup.id
     });
     const groups = await ctx.orm.group.findAll();

--- a/routes/group.js
+++ b/routes/group.js
@@ -1,4 +1,5 @@
 const KoaRouter = require("koa-router");
+const sectionFunctions = require("./sectionFunctions");
 
 const router = new KoaRouter();
 const sections = require("./section");
@@ -10,6 +11,11 @@ router.post("groups.create", "/", async ctx => {
   // TODO: create default section
   try {
     await newGroup.save({ fields: ["name", "foundationDate"] });
+    const newDefaultSection = await sectionFunctions.create(ctx, {
+      name: "Sin Unidad",
+      typeId: 1,
+      groupId: newGroup.id
+    });
     const groups = await ctx.orm.group.findAll();
     ctx.body = { groups };
   } catch (validationError) {

--- a/routes/section.js
+++ b/routes/section.js
@@ -1,4 +1,5 @@
 const KoaRouter = require("koa-router");
+const sectionFunctions = require("./sectionFunctions");
 
 const router = new KoaRouter();
 
@@ -19,15 +20,13 @@ router.get("sections.show", "/:section_id", async ctx => {
 });
 
 router.post("sections.create", "/", async ctx => {
-  const newSection = ctx.orm.section.build(ctx.request.body);
-  newSection.groupId = ctx.params.group_id;
-  try {
-    await newSection.save({ fields: ["name", "typeId", "groupId"] });
-    const sections = await ctx.orm.section.findAll();
-    ctx.body = { sections };
-  } catch (validationError) {
-    ctx.body = { errors: validationError.errors };
-  }
+  const { name, typeId } = ctx.request.body;
+  const newSection = await sectionFunctions.create(ctx, {
+    name,
+    typeId,
+    groupId: ctx.params.group_id
+  });
+  ctx.body = newSection;
 });
 
 router.patch("sections.update", "/:section_id", async ctx => {

--- a/routes/sectionFunctions.js
+++ b/routes/sectionFunctions.js
@@ -1,0 +1,13 @@
+module.exports = {
+  create: async function(ctx, requestBody) {
+    // requestBody = {name: string, typeId: int, groupId: int}
+    const newSection = ctx.orm.section.build(requestBody);
+    try {
+      await newSection.save({ fields: ["name", "typeId", "groupId"] });
+      const sections = await ctx.orm.section.findAll();
+      return { sections };
+    } catch (validationError) {
+      return { errors: validationError.errors };
+    }
+  }
+};

--- a/seeders/20190507221234-add-sectionTypes.js
+++ b/seeders/20190507221234-add-sectionTypes.js
@@ -2,6 +2,15 @@ module.exports = {
   up: queryInterface => {
     const sectionTypes = [
       {
+        name: "Sin Unidad",
+        minAge: 7,
+        maxAge: 99,
+        description: "Sin unidad",
+        gender: null,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
         name: "Bandada",
         minAge: 7,
         maxAge: 11,


### PR DESCRIPTION
-add default unit type seed
-move section creation to a function so we don't repeat code
-use section creation function from group routes